### PR TITLE
Added AR country code for Argentine accounts

### DIFF
--- a/src/types/ClientTypes.ts
+++ b/src/types/ClientTypes.ts
@@ -15,7 +15,8 @@ export type Country =
   | 'SL'
   | 'SR'
   | 'TR'
-  | 'US';
+  | 'US'
+  | 'AR';
 
 export type Methods = 'GET' | 'POST' | 'DELETE' | 'PUT' | 'PATCH';
 


### PR DESCRIPTION
Creating an account in Argentina yields much lower costs than other countries. To support type-checking with these accounts, the country code for Argentina has been added.